### PR TITLE
Added explanations for how to run unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ For building and running the tests, you can run this command:
 
 This should generate a coverage folder containing a index.htm file containing the code coverage report. You can open that up in chrome to see the coverage metrics. 
 
+#### Running Unit tests
+
+To run the unit tests in the Visual Studio Test Explorer you will need to have the xunit test runner nuget package installed. If that isn't already installed, you can install it to your EasyFarm.Tests project by managing the nuget packages via:
+
+Tools > Nuget Package Manager > Manage Nuget Packages for this solution...
+
+in the browse tab search for "xunit.runner.visualstudio" and install the test runner to the EasyFarm.Tests project.
+
+You should now be able to Run All tests in the test explorer.
+
 #### Special Thanks!
 
 * The FFEVO Team for producing the previous memory reading api this program could not operate without.


### PR DESCRIPTION
using a fresh Visual studio 2019 enterprise I did not have xunit test runner installed at all so I would get a (!) on all the unit tests which would get faded out. This was because there was no test runner installed to be able to run the tests. I'm not sure if that is a per project setting, or if you install it once and it is good for the rest of your projects.

I added instructions on how to install the xunit test runner to the readme. Alternatively I'm not sure if the package.json file could be updated to include the test runner and then this problem would be solved for everyone who opens the solution and tries to run the tests.