### PR TITLE
Bugfix: fixed bug where ffxi process select never filtered

### DIFF
--- a/EasyFarm/ViewModels/SelectProcessViewModel.cs
+++ b/EasyFarm/ViewModels/SelectProcessViewModel.cs
@@ -85,7 +85,7 @@ namespace EasyFarm.ViewModels
             Processes.Clear();
 
             Processes.AddRange(Process.GetProcessesByName(ProcessName)
-                .Where(x => string.IsNullOrWhiteSpace((x.MainWindowTitle)))
+                .Where(x => !string.IsNullOrWhiteSpace((x.MainWindowTitle)))
                 .ToList());
 
             if (Processes.Count > 0) return;


### PR DESCRIPTION
The process filter for selecting processes always shows all processes, because the pol section filters out all valid processes.

The Select Process function is supposed to filter to only ffxi processes, and then if there are no ffxi processes it should show all of them. Right now it will never show any ffxi processes because the first check is checking to make sure it is a ffxi process, AND that it has NO window title. What should happen is it looks for all ffxi processes, and then filters to only things WITH a window title.

By adding this bang it will make sure that only play online processes get through the first section, and make sure it has a window title instead of basically making the first section never get anything, and it always just do the default section of all processes.