### PR TITLE
Fix uncaught concurrency exception in PlayerMovementTracker

### DIFF
--- a/EasyFarm/States/PlayerMovementTracker.cs
+++ b/EasyFarm/States/PlayerMovementTracker.cs
@@ -26,6 +26,8 @@ namespace EasyFarm.States
 {
     public class PlayerMovementTracker
     {
+        private static readonly object LockObject = new object();
+
         private readonly IMemoryAPI _fface;
         private readonly Queue<Position> _positionHistory = new Queue<Position>();
 
@@ -36,17 +38,24 @@ namespace EasyFarm.States
 
         public void RunComponent()
         {
-            var position = _fface.Player.Position;
-            _positionHistory.Enqueue(Helpers.ToPosition(position.X, position.Y, position.Z, position.H));
-            if (_positionHistory.Count >= 15) _positionHistory.Dequeue();
+            lock (LockObject)
+            {
+                var position = _fface.Player.Position;
+                _positionHistory.Enqueue(Helpers.ToPosition(position.X, position.Y, position.Z, position.H));
+                if (_positionHistory.Count >= 15) _positionHistory.Dequeue();
+            }
             Player.Instance.IsMoving = IsMoving();
         }
 
         public bool IsMoving()
         {
-            var changeInX = _positionHistory.Average(positon => positon.X) - _fface.Player.PosX;
-            var changeInZ = _positionHistory.Average(position => position.Z) - _fface.Player.PosZ;
-            return Math.Abs(changeInX) + Math.Abs(changeInZ) > 0;
+            lock (LockObject)
+            {
+                var changeInX = _positionHistory.Average(positon => positon.X) - _fface.Player.PosX;
+                var changeInZ = _positionHistory.Average(position => position.Z) - _fface.Player.PosZ;
+                
+                return Math.Abs(changeInX) + Math.Abs(changeInZ) > 0;
+            }
         }
     }
 }


### PR DESCRIPTION
_positionHistory was being modified while being accessed, so I added a lock over the reads and writes