### PR TITLE
Fixing ranged attack

### DIFF
--- a/EasyFarm/Classes/BattleAbility.cs
+++ b/EasyFarm/Classes/BattleAbility.cs
@@ -529,6 +529,12 @@ namespace EasyFarm.Classes
         /// </summary>
         public async Task AutoFill()
         {
+            // Ensure that ranged attack is found in resources.
+            if (AbilityType == AbilityType.Range)
+            {
+                Name = "Ranged";
+            }
+
             // Return if string null or empty.
             if (string.IsNullOrWhiteSpace(Name)) return;
 
@@ -550,7 +556,6 @@ namespace EasyFarm.Classes
                 Id = ability.Id;
                 MpCost = ability.MpCost;
                 TpCost = ability.TpCost;
-                Command = ability.Command;
                 AbilityType = ability.AbilityType;
                 Name = ability.English;
                 TargetType = ability.TargetType.HasFlag(TargetType.Self) ? TargetType.Self : TargetType.Enemy;

--- a/EasyFarm/Parsing/CategoryType.cs
+++ b/EasyFarm/Parsing/CategoryType.cs
@@ -26,6 +26,7 @@ namespace EasyFarm.Parsing
         Unknown,
         WeaponSkill,
         Misc,
+        Range,
         JobAbility,
         PetCommand,
         CorsairRoll,

--- a/EasyFarm/Parsing/ResourceHelper.cs
+++ b/EasyFarm/Parsing/ResourceHelper.cs
@@ -74,6 +74,8 @@ namespace EasyFarm.Parsing
                     return CategoryType.WeaponSkill;
                 case "Misc":
                     return CategoryType.Misc;
+                case "Range":
+                    return CategoryType.Range;
                 case "JobAbility":
                     return CategoryType.JobAbility;
                 case "PetCommand":
@@ -227,6 +229,7 @@ namespace EasyFarm.Parsing
                 case AbilityType.Ninjutsu:
                 case AbilityType.Song:
                 case AbilityType.Item:
+                case AbilityType.Range:
                 case AbilityType.Trust:
                     return true;
                 default:
@@ -242,7 +245,6 @@ namespace EasyFarm.Parsing
             switch (abilityType)
             {
                 case AbilityType.Weaponskill:
-                case AbilityType.Range:
                 case AbilityType.Jobability:
                 case AbilityType.Pet:
                 case AbilityType.Monsterskill:


### PR DESCRIPTION
There seems to have been a bug introduced that effectively causes all ranged attacks to never auto-fill and always be filtered out, unless the user somehow magically knows to enter "Ranged" as the battle ability name so that the Resources lookup works correctly.

This adds a check that sets the name so that /range <t> can be used again!