### PR TITLE
Fix the process selector to only show PlayOnline processes

### DIFF
--- a/EasyFarm/ViewModels/SelectProcessViewModel.cs
+++ b/EasyFarm/ViewModels/SelectProcessViewModel.cs
@@ -85,7 +85,7 @@ namespace EasyFarm.ViewModels
             Processes.Clear();
 
             Processes.AddRange(Process.GetProcessesByName(ProcessName)
-                .Where(x => string.IsNullOrWhiteSpace((x.MainWindowTitle)))
+                .Where(x => !string.IsNullOrWhiteSpace((x.MainWindowTitle)))
                 .ToList());
 
             if (Processes.Count > 0) return;


### PR DESCRIPTION
Simple fix to the process selection logic to only show the PlayOnline processes.