### PR TITLE
Fix navigating with a single waypoint

### DIFF
--- a/EasyFarm/States/Route.cs
+++ b/EasyFarm/States/Route.cs
@@ -87,7 +87,12 @@ namespace EasyFarm.States
                 EasyFarm.ViewModels.LogViewModel.Write("Navigating to waypoint (" + _goal + ") " + closest.ToString());
 
                 return _nodes[_goal];
-            } 
+            }
+            else if (_nodes.Count < 2)
+            {
+                _goal = 0;
+                return _nodes[_goal];
+            }
             else if (_nodes.Count < 3)
             {
                 _goal = (_goal == 0) ? 1 : 0;
@@ -137,8 +142,27 @@ namespace EasyFarm.States
 
         public bool IsPathUnreachable(IGameContext context)
         {
-            return Zone == context.Player.Zone &&
-                context.NavMesh.FindPathBetween(context.API.Player.Position, GetNextPosition(context.API.Player.Position)).Count > 0;
+            if (Zone != context.Player.Zone)
+            {
+                return false;
+            }
+            else
+            {
+                Position nextPos = GetNextPosition(context.API.Player.Position);
+                if (nextPos != null)
+                {
+                    return (Distance(context.API.Player.Position, nextPos) < 0.5
+                           || context.NavMesh.FindPathBetween(context.API.Player.Position, GetNextPosition(context.API.Player.Position)).Count > 0
+                           );
+                }
+                else
+                {
+                    return false;
+                }
+            }
+     
+            //return Zone == context.Player.Zone &&
+            //       context.NavMesh.FindPathBetween(context.API.Player.Position, GetNextPosition(context.API.Player.Position)).Count > 0;
         }
     }
 }

--- a/EasyFarm/States/TravelState.cs
+++ b/EasyFarm/States/TravelState.cs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // If not, see <http://www.gnu.org/licenses/>.
 // ///////////////////////////////////////////////////////////////////
+using System;
 using System.Linq;
 using EasyFarm.Classes;
 using EasyFarm.Context;
@@ -64,6 +65,11 @@ namespace EasyFarm.States
                 currentPosition = context.Config.Route.GetNextPosition(context.API.Player.Position);
             }
 
+            if (currentPosition.Distance(context.API.Player.Position) < 0.5)
+            {
+                context.API.Follow.Reset();
+            }
+
             /*context.API.Navigator.GotoWaypoint(
                 nextPosition,
                 context.Config.IsObjectAvoidanceEnabled,
@@ -90,6 +96,7 @@ namespace EasyFarm.States
                 else
                 {
                     context.Config.Route.GetNextPosition(context.API.Player.Position);
+                    context.API.Follow.Reset();
                 }
             }
         }


### PR DESCRIPTION
This solves some problems with single waypoint pathing.

1) Allows you to start if you are close enough that the pathing software gives you a 0 length path
2) Keeps you from running back and forth on top of your waypoint by stopping the autorun once you get close enough.